### PR TITLE
Upgrade dd-agent from 5.8.5 to 5.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent:11.2.585
+FROM datadog/docker-dd-agent:11.0.591
 
 ADD conf.d/ /etc/dd-agent/conf.d/
 ADD checks.d/ /etc/dd-agent/checks.d/


### PR DESCRIPTION
New version allows to specify service discovery via kubernetes annotations.