### PR TITLE
Base image on latest agent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent:11.0.5130
+FROM datadog/docker-dd-agent:12.2.5172
 
 # Add some new features and fixes from upsteam
 # Not very elegant, but it is easier than creating custom deb package


### PR DESCRIPTION
Update base image based on CVE guidance from DataDog.

See: https://github.com/DataDog/docker-dd-agent/pull/238

Note this updates from agent image major version 11 -> 12. I have done a
cursory check as to what changes were introduced with 12, but did not
notice any that would require modification of our wrapper or usage.
Regardless, I've asked for [version change clarification](https://github.com/DataDog/docker-dd-agent/issues/240).