### PR TITLE
Downgrade dd-agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent:12.6.5230
+FROM datadog/docker-dd-agent:12.6.5223
 
 # Add some new features and fixes from upsteam
 # Not very elegant, but it is easier than creating custom deb package


### PR DESCRIPTION
5.23.0 [uses a very low timeout for kubernetes_state, which causes it to
fail][1] often. Downgrading to 5.22.3 has fixed this for others.

[1]: https://github.com/DataDog/integrations-core/issues/1346

INF-1648