### PR TITLE
Add conntrack_insert_failed metrics to Datadog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# required for reporting conntrack_insert_failed and conntrack_drop metrics
+RUN apt-get install -y --no-install-recommends conntrack
+
 COPY entrypoint-wrapper.sh /entrypoint-wrapper.sh
 
 ENTRYPOINT ["/entrypoint-wrapper.sh"]

--- a/checks.d/conntrack.py
+++ b/checks.d/conntrack.py
@@ -19,8 +19,38 @@ class Conntrack(AgentCheck):
         sysctl = sp.Popen(['cat', '/proc/sys/net/netfilter/nf_conntrack_count',
                            '/proc/sys/net/netfilter/nf_conntrack_max'],
                           stdout=sp.PIPE, close_fds=True).communicate()[0]
-        lines = sysctl.split('\n')
+        sysctl_lines = sysctl.split('\n')
         conntrack_info = {}
-        conntrack_info['conntrack_count'] = lines[0]
-        conntrack_info['conntrack_max'] = lines[1]
+        conntrack_info['conntrack_count'] = sysctl_lines[0]
+        conntrack_info['conntrack_max'] = sysctl_lines[1]
+
+        conntrack = sp.Popen(['conntrack', '-S'],
+                          stdout=sp.PIPE, close_fds=True).communicate()[0]
+        # Sample output:
+        # entries   		8112
+        # searched  		0
+        # found     		72556
+        # new       		0
+        # invalid   		3828562
+        # ignore    		13996314
+        # delete    		0
+        # delete_list		0
+        # insert    		0
+        # insert_failed		12783
+        # drop      		12783
+        # early_drop		0
+        # icmp_error		1
+        # expect_new		0
+        # expect_create		0
+        # expect_delete		0
+        # search_restart		32917695
+        conntrack_lines = conntrack.split('\n')
+        regexp = re.compile(r'^(\w+)\s+([0-9]+)')
+        for line in conntrack_lines:
+            try:
+                match = re.search(regexp, line)
+                if match is not None:
+                    conntrack_info['conntrack_{}'.format(match.group(1))] = match.group(2)
+            except Exception:
+                self.log.exception("Cannot parse %s" % (line,))
         return conntrack_info


### PR DESCRIPTION
INF-1688

In fact, this change also adds the whole output of `conntrack -S` command, such as conntrack_drop, conntrack_icmp_error, etc. Here is an example output:
```
{'conntrack_expect_new': '0', 'conntrack_entries': '6900', 'conntrack_icmp_error': '1', 'conntrack_delete_list': '0', 'conntrack_count': '6906', 'conntrack_delete': '0', 'conntrack_new': '0', 'conntrack_search_restart': '32915922', 'conntrack_searched': '0', 'conntrack_insert_failed': '12783', 'conntrack_expect_delete': '0', 'conntrack_max': '524288', 'conntrack_invalid': '3828268', 'conntrack_expect_create': '0', 'conntrack_ignore': '13994012', 'conntrack_found': '72550', 'conntrack_early_drop': '0', 'conntrack_insert': '0', 'conntrack_drop': '12783'}
```