### PR TITLE
Upgrade dd-agent to 5.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent:12.6.5223
+FROM datadog/docker-dd-agent:12.6.5250
 
 # Add some new features and fixes from upsteam
 # Not very elegant, but it is easier than creating custom deb package


### PR DESCRIPTION
This includes upgrades to the NGINX integration, which includes support for the
VTS status module. This means that we might be able to deprecate our own NGINX
VTS integration implemented here in this repository.

We had issues w/ kuberentes_state metrics in 2.23 and had to downgrade to
5.22.3 in 41ef2b2 ("Downgrade dd-agent", 2018-04-25). This [has been fixed][1]
in 5.24, though, so upgrading should be OK.

[1]: https://github.com/DataDog/integrations-core/issues/1346#issuecomment-389831560

INF-1675