### PR TITLE
Fix NTP check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD checks.d/ /etc/dd-agent/checks.d/
 # Apply patches
 ADD patches/*.patch /tmp/
 RUN apt-get update \
- && apt-get install --no-install-recommends -y patch \
+ && apt-get install --no-install-recommends -y patch netbase \
  && (for p in `ls /tmp/*.patch`; do echo "Applying: $p"; patch -p1 < $p || exit 1; done) \
  && apt-get remove -y --force-yes patch \
  && apt-get clean \


### PR DESCRIPTION
There's a dd-agent [issue][1], that causes NTP checks to fail with newest
releases. The agent depends on a /etc/services file, which doesn't exist in the
latest image, because the debian base image that's used doesn't include the
`netbase` package. Installing it here fixes the issue, which is also suggested
in a [comment][2].

In a later version of dd-agent, this package will likely no longer be required.

INF-1719

[1]: https://github.com/DataDog/dd-agent/issues/3762
[2]: https://github.com/DataDog/integrations-core/issues/1569#issuecomment-391253743