### PR TITLE
Upgrade Datadog agent to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/agent:6.5.1
+FROM datadog/agent:6.10.0
 
 # Required for reporting conntrack_insert_failed and conntrack_drop metrics
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack \


### PR DESCRIPTION
No specific reason. We use version 6.9 of the agent in our Ansible playbooks,
for example.