### PR TITLE
Update to 7.20.2 to add Istio v1.6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/agent:7.18.1
+FROM datadog/agent:7.20.2
 
 # Required for reporting conntrack_insert_failed and conntrack_drop metrics
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack \


### PR DESCRIPTION
[Commit][1] with new Istio support was merged to 7.20.0

[1]: https://github.com/DataDog/integrations-core/commit/c20e332400d1b027f54a2a8b269a6e073aba45c4