### PR TITLE
Update Datadog agent to 7.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/agent:7.22.1
+FROM datadog/agent:7.24.0
 
 # Required for reporting conntrack_insert_failed and conntrack_drop metrics
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack \


### PR DESCRIPTION
Changelog: https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7240--6240

This updates Postgres checks to version 5.2.1, which fixes noise
generated in Postgres logs by datadog agent.

Fix: https://github.com/DataDog/integrations-core/pull/7542