### PR TITLE
Update Datadog agent to 7.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/agent:7.24.0
+FROM datadog/agent:7.25.1
 
 # Required for reporting conntrack_insert_failed and conntrack_drop metrics
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack \


### PR DESCRIPTION
Changelog: https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7251

Important fixes:
* Fix memory leak on check unscheduling, which could be noticeable for checks submitting large amounts of metrics/tags.