### PR TITLE
Add Renovate bot to automatically update Datadog agent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-inf

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "assigneesFromCodeOwners": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["datadog/agent"]
+    }
+  ],
+  "pinDigests": true
+}


### PR DESCRIPTION
I followed [Renovate documentation][1] to create the configuration file.

[1]: https://docs.renovatebot.com/docker/