### PR TITLE
Add puma integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ FROM datadog/agent:7.25.1@sha256:538a3a9d8950ab90cfc37504a01908f8d03b65502836f66
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack \
  && rm -rf /var/lib/apt/lists/*
 
+RUN agent integration install -r -t datadog-puma==1.0.0
+
 ADD checks.d/ /checks.d


### PR DESCRIPTION
This allows us to use [puma][1] community plugin. Puma is our HTTP
server used in most of our ruby projects.

See example: https://github.com/salemove/visitor-information/pull/189/commits/87db805579892122cb75448a2dca18eb894b2601

[1]: https://github.com/DataDog/integrations-extras/tree/master/puma